### PR TITLE
feat: expose typed inline models in body parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - **패키지 로딩과 검증** – `hwpx.opc.package.HwpxPackage`로 `mimetype`, `container.xml`, `version.xml`을 확인하며 모든 파트를 메모리에 적재합니다.
 - **문서 편집 API** – `hwpx.document.HwpxDocument`는 문단과 표, 메모, 헤더 속성을 파이썬 객체로 노출하고 새 콘텐츠를 손쉽게 추가합니다. 섹션 머리말·꼬리말을 수정하면 `<hp:headerApply>`/`<hp:footerApply>`와 마스터 페이지 링크도 함께 갱신합니다.
+- **타입이 지정된 본문 모델** – `hwpx.oxml.body`는 표·컨트롤·인라인 도형·변경 추적 태그를 데이터 클래스에 매핑하고, `HwpxOxmlParagraph.model`/`HwpxOxmlRun.model`로 이를 조회·수정한 뒤 XML로 되돌릴 수 있도록 지원합니다.
 - **메모와 필드 앵커** – `add_memo_with_anchor()`로 메모를 생성하면서 MEMO 필드 컨트롤을 자동 삽입해 한/글에서 바로 표시되도록 합니다.
 - **스타일 기반 텍스트 치환** – 런 서식(색상, 밑줄, `charPrIDRef`)으로 필터링해 텍스트를 선택적으로 교체하거나 삭제합니다. 하이라이트
   마커나 태그로 분리된 문자열도 서식을 유지한 채 치환합니다.

--- a/src/hwpx/oxml/body.py
+++ b/src/hwpx/oxml/body.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from lxml import etree
 
 from .common import GenericElement, parse_generic_element
 from .utils import local_name, parse_bool, parse_int
 
+
+_DEFAULT_HP_NS = "http://www.hancom.co.kr/hwpml/2011/paragraph"
+_DEFAULT_HP = f"{{{_DEFAULT_HP_NS}}}"
 
 INLINE_OBJECT_NAMES = {
     "line",
@@ -17,38 +20,114 @@ INLINE_OBJECT_NAMES = {
     "polyline",
     "polygon",
     "curve",
+    "connectLine",
     "picture",
-    "tbl",
+    "pic",
     "shape",
     "drawingObject",
+    "container",
     "equation",
     "ole",
     "chart",
     "video",
     "audio",
+    "textart",
 }
+
+_TRACK_CHANGE_MARK_NAMES = {
+    "insertBegin",
+    "insertEnd",
+    "deleteBegin",
+    "deleteEnd",
+}
+
+InlineMark = Union[GenericElement, "TrackChangeMark"]
+RunChild = Union[GenericElement, "Control", "Table", "InlineObject", "TextSpan"]
+ParagraphChild = Union["Run", GenericElement]
+
+
+@dataclass(slots=True)
+class TrackChangeMark:
+    tag: str
+    name: str
+    change_type: str
+    is_begin: bool
+    para_end: Optional[bool]
+    tc_id: Optional[int]
+    id: Optional[int]
+    attributes: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TextMarkup:
+    element: InlineMark
+    trailing_text: str = ""
+
+    @property
+    def name(self) -> str:
+        if isinstance(self.element, TrackChangeMark):
+            return self.element.name
+        return self.element.name
 
 
 @dataclass(slots=True)
 class TextSpan:
-    text: str
-    marks: List[GenericElement] = field(default_factory=list)
+    tag: str
+    leading_text: str
+    marks: List[TextMarkup] = field(default_factory=list)
     attributes: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def text(self) -> str:
+        return self.leading_text + "".join(mark.trailing_text for mark in self.marks)
+
+    @text.setter
+    def text(self, value: str) -> None:
+        self.leading_text = value
+        for mark in self.marks:
+            mark.trailing_text = ""
+
+
+@dataclass(slots=True)
+class Control:
+    tag: str
+    control_type: Optional[str]
+    attributes: Dict[str, str] = field(default_factory=dict)
+    children: List[GenericElement] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class InlineObject:
+    tag: str
+    name: str
+    attributes: Dict[str, str] = field(default_factory=dict)
+    children: List[GenericElement] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class Table:
+    tag: str
+    attributes: Dict[str, str] = field(default_factory=dict)
+    children: List[GenericElement] = field(default_factory=list)
 
 
 @dataclass(slots=True)
 class Run:
+    tag: str
     char_pr_id_ref: Optional[int]
     section_properties: List[GenericElement] = field(default_factory=list)
-    controls: List[GenericElement] = field(default_factory=list)
-    inline_objects: List[GenericElement] = field(default_factory=list)
+    controls: List[Control] = field(default_factory=list)
+    tables: List[Table] = field(default_factory=list)
+    inline_objects: List[InlineObject] = field(default_factory=list)
     text_spans: List[TextSpan] = field(default_factory=list)
     other_children: List[GenericElement] = field(default_factory=list)
     attributes: Dict[str, str] = field(default_factory=dict)
+    content: List[RunChild] = field(default_factory=list)
 
 
 @dataclass(slots=True)
 class Paragraph:
+    tag: str
     id: Optional[int]
     para_pr_id_ref: Optional[int]
     style_id_ref: Optional[int]
@@ -58,49 +137,127 @@ class Paragraph:
     runs: List[Run] = field(default_factory=list)
     attributes: Dict[str, str] = field(default_factory=dict)
     other_children: List[GenericElement] = field(default_factory=list)
+    content: List[ParagraphChild] = field(default_factory=list)
 
 
 @dataclass(slots=True)
 class Section:
+    tag: str
     attributes: Dict[str, str]
     paragraphs: List[Paragraph] = field(default_factory=list)
     other_children: List[GenericElement] = field(default_factory=list)
 
 
-def parse_text_span(node: etree._Element) -> TextSpan:
-    parts: List[str] = []
-    marks: List[GenericElement] = []
+def _qualified_tag(tag: Optional[str], name: str) -> str:
+    if tag:
+        return tag
+    return f"{_DEFAULT_HP}{name}"
 
-    if node.text:
-        parts.append(node.text)
+
+def _bool_to_str(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def parse_track_change_mark(node: etree._Element) -> TrackChangeMark:
+    attrs = {key: value for key, value in node.attrib.items()}
+    para_end = parse_bool(attrs.pop("paraend", None))
+    tc_id = parse_int(attrs.pop("TcId", None))
+    mark_id = parse_int(attrs.pop("Id", None))
+    name = local_name(node)
+    change_type = "insert" if name.startswith("insert") else "delete"
+    is_begin = name.endswith("Begin")
+    return TrackChangeMark(
+        tag=node.tag,
+        name=name,
+        change_type=change_type,
+        is_begin=is_begin,
+        para_end=para_end,
+        tc_id=tc_id,
+        id=mark_id,
+        attributes=attrs,
+    )
+
+
+def _parse_text_markup(node: etree._Element) -> InlineMark:
+    name = local_name(node)
+    if name in _TRACK_CHANGE_MARK_NAMES:
+        return parse_track_change_mark(node)
+    return parse_generic_element(node)
+
+
+def parse_text_span(node: etree._Element) -> TextSpan:
+    leading = node.text or ""
+    marks: List[TextMarkup] = []
 
     for child in node:
-        marks.append(parse_generic_element(child))
-        if child.tail:
-            parts.append(child.tail)
+        mark = _parse_text_markup(child)
+        trailing = child.tail or ""
+        marks.append(TextMarkup(mark, trailing))
 
-    text = "".join(parts)
-    return TextSpan(text=text, marks=marks, attributes={key: value for key, value in node.attrib.items()})
+    return TextSpan(
+        tag=node.tag,
+        leading_text=leading,
+        marks=marks,
+        attributes={key: value for key, value in node.attrib.items()},
+    )
+
+
+def parse_control_element(node: etree._Element) -> Control:
+    attrs = {key: value for key, value in node.attrib.items()}
+    control_type = attrs.pop("type", None)
+    children = [parse_generic_element(child) for child in node]
+    return Control(tag=node.tag, control_type=control_type, attributes=attrs, children=children)
+
+
+def parse_inline_object_element(node: etree._Element) -> InlineObject:
+    return InlineObject(
+        tag=node.tag,
+        name=local_name(node),
+        attributes={key: value for key, value in node.attrib.items()},
+        children=[parse_generic_element(child) for child in node],
+    )
+
+
+def parse_table_element(node: etree._Element) -> Table:
+    return Table(
+        tag=node.tag,
+        attributes={key: value for key, value in node.attrib.items()},
+        children=[parse_generic_element(child) for child in node],
+    )
 
 
 def parse_run_element(node: etree._Element) -> Run:
     attributes = {key: value for key, value in node.attrib.items()}
     char_pr_id_ref = parse_int(attributes.pop("charPrIDRef", None))
 
-    run = Run(char_pr_id_ref=char_pr_id_ref, attributes=attributes)
+    run = Run(tag=node.tag, char_pr_id_ref=char_pr_id_ref, attributes=attributes)
 
     for child in node:
         name = local_name(child)
         if name == "secPr":
-            run.section_properties.append(parse_generic_element(child))
+            element = parse_generic_element(child)
+            run.section_properties.append(element)
+            run.content.append(element)
         elif name == "ctrl":
-            run.controls.append(parse_generic_element(child))
+            control = parse_control_element(child)
+            run.controls.append(control)
+            run.content.append(control)
         elif name == "t":
-            run.text_spans.append(parse_text_span(child))
+            span = parse_text_span(child)
+            run.text_spans.append(span)
+            run.content.append(span)
+        elif name == "tbl":
+            table = parse_table_element(child)
+            run.tables.append(table)
+            run.content.append(table)
         elif name in INLINE_OBJECT_NAMES:
-            run.inline_objects.append(parse_generic_element(child))
+            obj = parse_inline_object_element(child)
+            run.inline_objects.append(obj)
+            run.content.append(obj)
         else:
-            run.other_children.append(parse_generic_element(child))
+            element = parse_generic_element(child)
+            run.other_children.append(element)
+            run.content.append(element)
 
     return run
 
@@ -109,6 +266,7 @@ def parse_paragraph_element(node: etree._Element) -> Paragraph:
     attributes = {key: value for key, value in node.attrib.items()}
 
     paragraph = Paragraph(
+        tag=node.tag,
         id=parse_int(attributes.pop("id", None)),
         para_pr_id_ref=parse_int(attributes.pop("paraPrIDRef", None)),
         style_id_ref=parse_int(attributes.pop("styleIDRef", None)),
@@ -120,15 +278,19 @@ def parse_paragraph_element(node: etree._Element) -> Paragraph:
 
     for child in node:
         if local_name(child) == "run":
-            paragraph.runs.append(parse_run_element(child))
+            run = parse_run_element(child)
+            paragraph.runs.append(run)
+            paragraph.content.append(run)
         else:
-            paragraph.other_children.append(parse_generic_element(child))
+            element = parse_generic_element(child)
+            paragraph.other_children.append(element)
+            paragraph.content.append(element)
 
     return paragraph
 
 
 def parse_section_element(node: etree._Element) -> Section:
-    section = Section(attributes={key: value for key, value in node.attrib.items()})
+    section = Section(tag=node.tag, attributes={key: value for key, value in node.attrib.items()})
 
     for child in node:
         if local_name(child) == "p":
@@ -139,13 +301,132 @@ def parse_section_element(node: etree._Element) -> Section:
     return section
 
 
+def _generic_element_to_xml(element: GenericElement) -> etree._Element:
+    node = etree.Element(_qualified_tag(element.tag, element.name))
+    for key, value in element.attributes.items():
+        node.set(key, value)
+    if element.text:
+        node.text = element.text
+    for child in element.children:
+        node.append(_generic_element_to_xml(child))
+    return node
+
+
+def _track_change_mark_to_xml(mark: TrackChangeMark) -> etree._Element:
+    attrs = dict(mark.attributes)
+    if mark.para_end is not None:
+        attrs["paraend"] = _bool_to_str(mark.para_end)
+    if mark.tc_id is not None:
+        attrs["TcId"] = str(mark.tc_id)
+    if mark.id is not None:
+        attrs["Id"] = str(mark.id)
+    return etree.Element(_qualified_tag(mark.tag, mark.name), attrs)
+
+
+def _inline_mark_to_xml(mark: InlineMark) -> etree._Element:
+    if isinstance(mark, TrackChangeMark):
+        return _track_change_mark_to_xml(mark)
+    return _generic_element_to_xml(mark)
+
+
+def _text_span_to_xml(span: TextSpan) -> etree._Element:
+    node = etree.Element(_qualified_tag(span.tag, "t"), dict(span.attributes))
+    if span.leading_text:
+        node.text = span.leading_text
+    for mark in span.marks:
+        child = _inline_mark_to_xml(mark.element)
+        node.append(child)
+        if mark.trailing_text:
+            child.tail = mark.trailing_text
+    return node
+
+
+def _control_to_xml(control: Control) -> etree._Element:
+    attrs = dict(control.attributes)
+    if control.control_type is not None:
+        attrs["type"] = control.control_type
+    node = etree.Element(_qualified_tag(control.tag, "ctrl"), attrs)
+    for child in control.children:
+        node.append(_generic_element_to_xml(child))
+    return node
+
+
+def _table_to_xml(table: Table) -> etree._Element:
+    node = etree.Element(_qualified_tag(table.tag, "tbl"), dict(table.attributes))
+    for child in table.children:
+        node.append(_generic_element_to_xml(child))
+    return node
+
+
+def _inline_object_to_xml(obj: InlineObject) -> etree._Element:
+    node = etree.Element(_qualified_tag(obj.tag, obj.name), dict(obj.attributes))
+    for child in obj.children:
+        node.append(_generic_element_to_xml(child))
+    return node
+
+
+def serialize_run(run: Run) -> etree._Element:
+    attrs = dict(run.attributes)
+    if run.char_pr_id_ref is not None:
+        attrs["charPrIDRef"] = str(run.char_pr_id_ref)
+    node = etree.Element(_qualified_tag(run.tag, "run"), attrs)
+    for child in run.content:
+        if isinstance(child, TextSpan):
+            node.append(_text_span_to_xml(child))
+        elif isinstance(child, Control):
+            node.append(_control_to_xml(child))
+        elif isinstance(child, Table):
+            node.append(_table_to_xml(child))
+        elif isinstance(child, InlineObject):
+            node.append(_inline_object_to_xml(child))
+        else:
+            node.append(_generic_element_to_xml(child))
+    return node
+
+
+def serialize_paragraph(paragraph: Paragraph) -> etree._Element:
+    attrs = dict(paragraph.attributes)
+    if paragraph.id is not None:
+        attrs["id"] = str(paragraph.id)
+    if paragraph.para_pr_id_ref is not None:
+        attrs["paraPrIDRef"] = str(paragraph.para_pr_id_ref)
+    if paragraph.style_id_ref is not None:
+        attrs["styleIDRef"] = str(paragraph.style_id_ref)
+    if paragraph.page_break is not None:
+        attrs["pageBreak"] = _bool_to_str(paragraph.page_break)
+    if paragraph.column_break is not None:
+        attrs["columnBreak"] = _bool_to_str(paragraph.column_break)
+    if paragraph.merged is not None:
+        attrs["merged"] = _bool_to_str(paragraph.merged)
+
+    node = etree.Element(_qualified_tag(paragraph.tag, "p"), attrs)
+    for child in paragraph.content:
+        if isinstance(child, Run):
+            node.append(serialize_run(child))
+        else:
+            node.append(_generic_element_to_xml(child))
+    return node
+
+
 __all__ = [
+    "Control",
+    "InlineObject",
+    "INLINE_OBJECT_NAMES",
     "Paragraph",
     "Run",
     "Section",
+    "Table",
+    "TextMarkup",
     "TextSpan",
+    "TrackChangeMark",
+    "parse_control_element",
+    "parse_inline_object_element",
     "parse_paragraph_element",
     "parse_run_element",
     "parse_section_element",
+    "parse_table_element",
     "parse_text_span",
+    "parse_track_change_mark",
+    "serialize_paragraph",
+    "serialize_run",
 ]

--- a/src/hwpx/oxml/common.py
+++ b/src/hwpx/oxml/common.py
@@ -13,6 +13,7 @@ class GenericElement:
     """Fallback representation for XML elements without a specialised model."""
 
     name: str
+    tag: Optional[str] = None
     attributes: Dict[str, str] = field(default_factory=dict)
     children: List["GenericElement"] = field(default_factory=list)
     text: Optional[str] = None
@@ -25,6 +26,7 @@ def parse_generic_element(node: etree._Element) -> GenericElement:
     text = node.text if node.text is not None else None
     return GenericElement(
         name=local_name(node),
+        tag=node.tag,
         attributes={key: value for key, value in node.attrib.items()},
         children=children,
         text=text,

--- a/src/hwpx/oxml/parser.py
+++ b/src/hwpx/oxml/parser.py
@@ -23,6 +23,13 @@ _ELEMENT_FACTORY: Dict[str, ParserFn] = {
     "t": body.parse_text_span,
 }
 
+_ELEMENT_FACTORY["ctrl"] = body.parse_control_element
+_ELEMENT_FACTORY["tbl"] = body.parse_table_element
+for name in body.INLINE_OBJECT_NAMES:
+    _ELEMENT_FACTORY.setdefault(name, body.parse_inline_object_element)
+for mark_name in ("insertBegin", "insertEnd", "deleteBegin", "deleteEnd"):
+    _ELEMENT_FACTORY.setdefault(mark_name, body.parse_track_change_mark)
+
 
 def element_to_model(node: etree._Element) -> object:
     """Convert *node* into the corresponding Python object."""

--- a/tests/test_inline_models.py
+++ b/tests/test_inline_models.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from hwpx.oxml import HwpxOxmlSection
+from hwpx.oxml.body import TrackChangeMark
+from hwpx.oxml.parser import parse_section_xml
+
+
+_HP_NS = "http://www.hancom.co.kr/hwpml/2011/paragraph"
+_HS_NS = "http://www.hancom.co.kr/hwpml/2011/section"
+
+
+def _sample_section_xml() -> str:
+    return (
+        "<hs:sec xmlns:hs='"
+        f"{_HS_NS}' xmlns:hp='{_HP_NS}'>"
+        "<hp:p id='1' paraPrIDRef='1' styleIDRef='2'>"
+        "<hp:run charPrIDRef='0'>"
+        "<hp:ctrl type='FORM' id='ctrl1'>"
+        "<hp:fieldBegin id='7' type='DATE'/>"
+        "</hp:ctrl>"
+        "<hp:t charStyleIDRef='3'>Prefix"
+        "<hp:insertBegin TcId='7' Id='3'/>"
+        "Middle"
+        "<hp:insertEnd TcId='7' paraend='false'/>"
+        "Suffix"
+        "</hp:t>"
+        "<hp:tbl width='2400'>"
+        "<hp:tr><hp:tc><hp:cellAddr rowAddr='1' colAddr='1'/></hp:tc></hp:tr>"
+        "</hp:tbl>"
+        "<hp:line shapeID='ln1' linewidth='2'/>"
+        "</hp:run>"
+        "</hp:p>"
+        "</hs:sec>"
+    )
+
+
+def test_run_model_contains_typed_children() -> None:
+    section = parse_section_xml(_sample_section_xml())
+    paragraph = section.paragraphs[0]
+    run = paragraph.runs[0]
+
+    control = run.controls[0]
+    assert control.control_type == "FORM"
+    assert control.attributes["id"] == "ctrl1"
+    assert control.children and control.children[0].name == "fieldBegin"
+
+    span = run.text_spans[0]
+    assert span.leading_text == "Prefix"
+    marks = [mark for mark in span.marks if isinstance(mark.element, TrackChangeMark)]
+    assert marks and marks[0].element.tc_id == 7
+    assert marks[0].element.is_begin is True
+    assert marks[0].trailing_text == "Middle"
+
+    table = run.tables[0]
+    assert table.attributes["width"] == "2400"
+    assert table.children and table.children[0].name == "tr"
+
+    inline = run.inline_objects[0]
+    assert inline.name == "line"
+    assert inline.attributes["shapeID"] == "ln1"
+
+    child_types = [type(child).__name__ for child in run.content]
+    assert child_types == ["Control", "TextSpan", "Table", "InlineObject"]
+
+
+def test_run_and_paragraph_round_trip_after_mutation() -> None:
+    section_element = ET.fromstring(_sample_section_xml())
+    section = HwpxOxmlSection("section0.xml", section_element)
+    paragraph = section.paragraphs[0]
+    run = paragraph.runs[0]
+
+    run_model = run.to_model()
+    run_model.char_pr_id_ref = 5
+    run_model.controls[0].control_type = "PAGE_NUMBER"
+    run_model.controls[0].attributes["id"] = "ctrl2"
+    run_model.tables[0].attributes["width"] = "3600"
+    run_model.inline_objects[0].attributes["linewidth"] = "3"
+
+    span = run_model.text_spans[0]
+    span.leading_text = "Intro"
+    track_marks = [mark for mark in span.marks if isinstance(mark.element, TrackChangeMark)]
+    assert track_marks  # sanity guard
+    track_marks[0].element.tc_id = 13
+    span.marks[0].trailing_text = "Body"
+    span.marks[1].trailing_text = "Outro"
+
+    run.apply_model(run_model)
+    updated_model = run.to_model()
+
+    assert updated_model.char_pr_id_ref == 5
+    assert updated_model.controls[0].control_type == "PAGE_NUMBER"
+    assert updated_model.controls[0].attributes["id"] == "ctrl2"
+    assert updated_model.tables[0].attributes["width"] == "3600"
+    assert updated_model.inline_objects[0].attributes["linewidth"] == "3"
+
+    updated_span = updated_model.text_spans[0]
+    assert updated_span.leading_text == "Intro"
+    updated_marks = [mark for mark in updated_span.marks if isinstance(mark.element, TrackChangeMark)]
+    assert updated_marks and updated_marks[0].element.tc_id == 13
+    assert updated_span.marks[0].trailing_text == "Body"
+    assert updated_span.marks[1].trailing_text == "Outro"
+
+    paragraph_model = paragraph.to_model()
+    paragraph_model.para_pr_id_ref = 9
+    paragraph_model.runs[0].controls[0].attributes["name"] = "renamed"
+
+    paragraph.apply_model(paragraph_model)
+    roundtrip = paragraph.to_model()
+
+    assert roundtrip.para_pr_id_ref == 9
+    assert roundtrip.runs[0].controls[0].attributes["name"] == "renamed"


### PR DESCRIPTION
## Summary
- extend the body parser to map controls, tables, inline objects and track-change tags onto dedicated dataclasses with round-trip serialization helpers
- surface the parsed models through `HwpxOxmlParagraph.model` / `HwpxOxmlRun.model` and register the new parsers with the generic element factory
- document the workflow and add regression tests that cover tables, controls, inline objects and track-change markers

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb89b0da6c8329a4ea694de285c845