### PR TITLE
Clear table cell layout cache before updating text

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ document.save("output/example.hwpx")
 
 `HwpxDocument.add_table()`은 문서에 정의된 테두리 채우기가 없으면 헤더 참조 목록에 "기본 실선" `borderFill`을 만들어 표와 모든 셀에 참조를 연결합니다.
 
+표 셀 텍스트를 편집하는 `table.set_cell_text()`는 기존 단락에 남아 있는 `lineSegArray`와 같은 줄 배치 캐시를 제거하여 한/글이 문서를 다시 열 때 줄바꿈을 새로 계산하도록 합니다.
+
 더 많은 실전 패턴은 [빠른 시작](docs/quickstart.md)과 [사용 가이드](docs/usage.md)의 "빠른 예제 모음"에서 확인할 수 있습니다.
 
 ## 문서

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -357,7 +357,7 @@
 - `set_span(row_span, col_span)`: 병합 속성을 업데이트하고 표를 dirty로 표시합니다.
 - `width`, `height`: `<hp:cellSz>`에서 캐시된 셀 크기를 노출하는 프로퍼티입니다.
 - `set_size(width=None, height=None)`: 크기 속성을 0 또는 그 이상으로 업데이트합니다.
-- `text`: 셀 내부의 첫 번째 텍스트 노드를 반환하는 프로퍼티입니다. setter는 텍스트를 할당하기 전에 중첩된 단락 구조가 있는지 확인합니다.
+- `text`: 셀 내부의 첫 번째 텍스트 노드를 반환하는 프로퍼티입니다. setter는 텍스트를 할당하기 전에 중첩된 단락 구조를 보장하고, `<hp:lineSegArray>`와 같은 줄 배치 캐시를 제거하여 한/글이 줄바꿈을 다시 계산하도록 합니다.
 - `remove()`: 행에서 셀 엘리먼트를 제거합니다.
 - `_addr_element()`, `_span_element()`, `_size_element()`, `_ensure_text_element()`: 중첩된 XML 구조를 관리하는 내부 헬퍼입니다.
 
@@ -372,7 +372,7 @@
 - `row_count`, `column_count`: 저장된 행/열 수를 확인하거나 XML 구조에서 파생하는 프로퍼티입니다.
 - `rows`: `HwpxOxmlTableRow` 래퍼를 반환하는 프로퍼티입니다.
 - `cell(row_index, col_index)`: 병합 정보를 고려하여 요청된 그리드 좌표를 포함하는 셀을 찾습니다.
-- `set_cell_text(row_index, col_index, text)`: 셀의 텍스트 내용을 업데이트하는 단축 메서드입니다.
+- `set_cell_text(row_index, col_index, text)`: 셀의 텍스트 내용을 업데이트하는 단축 메서드입니다. 내부적으로 줄 배치 캐시를 비워 한/글에서 셀 텍스트 변경 후 줄바꿈이 재계산되도록 합니다.
 - `merge_cells(start_row, ...)`: 직사각형 영역의 유효성을 검사하고, 종속 셀을 제거하며, 병합 및 크기 값을 업데이트한 후, 살아남은 대상 셀을 반환합니다.
 
 ### 클래스 `HwpxOxmlParagraph`

--- a/src/hwpx/oxml/document.py
+++ b/src/hwpx/oxml/document.py
@@ -119,6 +119,17 @@ def _create_paragraph_element(
     return paragraph
 
 
+_LAYOUT_CACHE_ELEMENT_NAMES = {"lineSegArray"}
+
+
+def _clear_paragraph_layout_cache(paragraph: ET.Element) -> None:
+    """Remove cached layout metadata such as ``<hp:lineSegArray>``."""
+
+    for child in list(paragraph):
+        if _element_local_name(child) in _LAYOUT_CACHE_ELEMENT_NAMES:
+            paragraph.remove(child)
+
+
 def _element_local_name(node: ET.Element) -> str:
     tag = node.tag
     if "}" in tag:
@@ -1501,6 +1512,7 @@ class HwpxOxmlTableCell:
         paragraph = sublist.find(f"{_HP}p")
         if paragraph is None:
             paragraph = ET.SubElement(sublist, f"{_HP}p", _default_cell_paragraph_attributes())
+        _clear_paragraph_layout_cache(paragraph)
         run = paragraph.find(f"{_HP}run")
         if run is None:
             run = ET.SubElement(paragraph, f"{_HP}run", {"charPrIDRef": "0"})

--- a/tests/test_document_formatting.py
+++ b/tests/test_document_formatting.py
@@ -295,6 +295,31 @@ def test_document_add_table_creates_table_structure() -> None:
     assert section.dirty is True
 
 
+def test_table_set_cell_text_removes_layout_cache() -> None:
+    section_element = ET.Element(f"{HS}sec")
+    section = HwpxOxmlSection("section0.xml", section_element)
+    manifest = ET.Element("manifest")
+    root = HwpxOxmlDocument(manifest, [section], [])
+    document = HwpxDocument(cast(HwpxPackage, object()), root)
+
+    table = document.add_table(1, 1, section=section)
+    cell = table.cell(0, 0)
+    sublist = cell.element.find(f"{HP}subList")
+    assert sublist is not None
+    paragraph = sublist.find(f"{HP}p")
+    assert paragraph is not None
+    ET.SubElement(paragraph, f"{HP}lineSegArray")
+    assert paragraph.find(f"{HP}lineSegArray") is not None
+    text_element = paragraph.find(f".//{HP}t")
+    assert text_element is not None
+    text_element.text = "Cached"
+
+    table.set_cell_text(0, 0, "Updated")
+
+    assert table.cell(0, 0).text == "Updated"
+    assert paragraph.find(f"{HP}lineSegArray") is None
+
+
 def test_table_merge_cells_updates_spans_and_structure() -> None:
     section_element = ET.Element(f"{HS}sec")
     section = HwpxOxmlSection("section0.xml", section_element)


### PR DESCRIPTION
## Summary
- remove cached line layout metadata from table cell paragraphs before updating <hp:t>
- add a regression test ensuring set_cell_text clears lineSegArray entries
- document that table editing purges cached layout information for proper wrapping

## Testing
- pytest tests/test_document_formatting.py

------
https://chatgpt.com/codex/tasks/task_e_68cec2dc1d2c8329a4f271d7451f63a0