### PR TITLE
Handle lowercase layout cache nodes when updating paragraphs

### DIFF
--- a/src/hwpx/oxml/document.py
+++ b/src/hwpx/oxml/document.py
@@ -119,14 +119,14 @@ def _create_paragraph_element(
     return paragraph
 
 
-_LAYOUT_CACHE_ELEMENT_NAMES = {"lineSegArray"}
+_LAYOUT_CACHE_ELEMENT_NAMES = {"linesegarray"}
 
 
 def _clear_paragraph_layout_cache(paragraph: ET.Element) -> None:
     """Remove cached layout metadata such as ``<hp:lineSegArray>``."""
 
     for child in list(paragraph):
-        if _element_local_name(child) in _LAYOUT_CACHE_ELEMENT_NAMES:
+        if _element_local_name(child).lower() in _LAYOUT_CACHE_ELEMENT_NAMES:
             paragraph.remove(child)
 
 

--- a/tests/test_document_formatting.py
+++ b/tests/test_document_formatting.py
@@ -309,7 +309,9 @@ def test_table_set_cell_text_removes_layout_cache() -> None:
     paragraph = sublist.find(f"{HP}p")
     assert paragraph is not None
     ET.SubElement(paragraph, f"{HP}lineSegArray")
+    ET.SubElement(paragraph, f"{HP}linesegarray")
     assert paragraph.find(f"{HP}lineSegArray") is not None
+    assert paragraph.find(f"{HP}linesegarray") is not None
     text_element = paragraph.find(f".//{HP}t")
     assert text_element is not None
     text_element.text = "Cached"
@@ -318,6 +320,7 @@ def test_table_set_cell_text_removes_layout_cache() -> None:
 
     assert table.cell(0, 0).text == "Updated"
     assert paragraph.find(f"{HP}lineSegArray") is None
+    assert paragraph.find(f"{HP}linesegarray") is None
 
 
 def test_table_merge_cells_updates_spans_and_structure() -> None:


### PR DESCRIPTION
## Summary
- normalize the layout cache allowlist to compare paragraph child elements case-insensitively
- extend the formatting regression test to cover lowercase hp:linesegarray elements and ensure they are removed

## Testing
- pytest tests/test_document_formatting.py

------
https://chatgpt.com/codex/tasks/task_e_68cecc8c58c88329afe79ad4ba9fe9f3