### PR TITLE
Mark table cells dirty after text updates

### DIFF
--- a/src/hwpx/oxml/document.py
+++ b/src/hwpx/oxml/document.py
@@ -1572,6 +1572,7 @@ class HwpxOxmlTableCell:
     def text(self, value: str) -> None:
         text_element = self._ensure_text_element()
         text_element.text = value
+        self.element.set("dirty", "1")
         self.table.mark_dirty()
 
     def remove(self) -> None:

--- a/tests/test_document_formatting.py
+++ b/tests/test_document_formatting.py
@@ -323,6 +323,28 @@ def test_table_set_cell_text_removes_layout_cache() -> None:
     assert paragraph.find(f"{HP}linesegarray") is None
 
 
+def test_table_cell_text_marks_cell_dirty_attribute() -> None:
+    section_element = ET.Element(f"{HS}sec")
+    section = HwpxOxmlSection("section0.xml", section_element)
+    manifest = ET.Element("manifest")
+    root = HwpxOxmlDocument(manifest, [section], [])
+    document = HwpxDocument(cast(HwpxPackage, object()), root)
+
+    table = document.add_table(1, 1, section=section)
+    cell = table.cell(0, 0)
+    assert cell.element.get("dirty") == "0"
+
+    cell.text = "Updated"
+
+    assert cell.element.get("dirty") == "1"
+
+    cell.element.set("dirty", "0")
+
+    table.set_cell_text(0, 0, "Again")
+
+    assert table.cell(0, 0).element.get("dirty") == "1"
+
+
 def test_table_merge_cells_updates_spans_and_structure() -> None:
     section_element = ET.Element(f"{HS}sec")
     section = HwpxOxmlSection("section0.xml", section_element)


### PR DESCRIPTION
## Summary
- ensure updating HwpxOxmlTableCell.text sets the cell's dirty attribute so layout is recomputed
- add regression coverage confirming table cell text updates toggle the dirty flag

## Testing
- pytest tests/test_document_formatting.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2b325f588329bd77614681dc2588