### PR TITLE
fix(oxml): use _append_child for cell/run text + run-style modifier (closes #30)

### DIFF
--- a/src/hwpx/oxml/document.py
+++ b/src/hwpx/oxml/document.py
@@ -2030,17 +2030,21 @@ class HwpxOxmlTableCell:
     def _ensure_text_element(self) -> ET.Element:
         sublist = self.element.find(f"{_HP}subList")
         if sublist is None:
-            sublist = ET.SubElement(self.element, f"{_HP}subList", _default_sublist_attributes())
+            sublist = _append_child(
+                self.element, f"{_HP}subList", _default_sublist_attributes()
+            )
         paragraph = sublist.find(f"{_HP}p")
         if paragraph is None:
-            paragraph = ET.SubElement(sublist, f"{_HP}p", _default_cell_paragraph_attributes())
+            paragraph = _append_child(
+                sublist, f"{_HP}p", _default_cell_paragraph_attributes()
+            )
         _clear_paragraph_layout_cache(paragraph)
         run = paragraph.find(f"{_HP}run")
         if run is None:
-            run = ET.SubElement(paragraph, f"{_HP}run", {"charPrIDRef": "0"})
+            run = _append_child(paragraph, f"{_HP}run", {"charPrIDRef": "0"})
         text = run.find(f"{_HP}t")
         if text is None:
-            text = ET.SubElement(run, f"{_HP}t")
+            text = _append_child(run, f"{_HP}t")
         return text
 
     @property
@@ -4535,9 +4539,9 @@ class HwpxOxmlDocument:
                 element.remove(child)
 
             if target[0]:
-                ET.SubElement(element, f"{_HH}bold")
+                _append_child(element, f"{_HH}bold")
             if target[1]:
-                ET.SubElement(element, f"{_HH}italic")
+                _append_child(element, f"{_HH}italic")
 
             underline_attrs = dict(base_underline_attrs)
             if target[2]:
@@ -4549,14 +4553,14 @@ class HwpxOxmlDocument:
                     underline_attrs["color"] = base_underline_attrs["color"]
                 if "color" not in underline_attrs:
                     underline_attrs["color"] = "#000000"
-                ET.SubElement(element, f"{_HH}underline", underline_attrs)
+                _append_child(element, f"{_HH}underline", underline_attrs)
             else:
                 attrs = dict(base_underline_attrs)
                 attrs["type"] = "NONE"
                 attrs.setdefault("shape", base_underline_attrs.get("shape", "SOLID"))
                 if "color" in base_underline_attrs:
                     attrs["color"] = base_underline_attrs["color"]
-                ET.SubElement(element, f"{_HH}underline", attrs)
+                _append_child(element, f"{_HH}underline", attrs)
 
         element = header.ensure_char_property(
             predicate=predicate,

--- a/tests/test_document_formatting.py
+++ b/tests/test_document_formatting.py
@@ -750,3 +750,47 @@ def test_paragraph_add_shape_and_control_updates_attributes() -> None:
     control.set_attribute("id", None)
     assert control.get_attribute("id") is None
     assert section.dirty is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: issue #30 — stdlib ET.SubElement called on lxml _Element
+# https://github.com/airmang/python-hwpx/issues/30
+# ---------------------------------------------------------------------------
+
+
+def test_issue_30_set_cell_text_on_blank_cell() -> None:
+    """Setting ``cell.text`` on a cell that lacks ``<hp:subList>/<hp:p>/<hp:run>``
+    must not raise ``TypeError``.
+
+    Before the fix, ``HwpxOxmlTableCell._ensure_text_element`` used
+    ``ET.SubElement`` (stdlib) on ``self.element`` which is an
+    ``lxml.etree._Element``. This reproduces the call path reported by
+    ``@devnoff`` in issue #30 and by downstream consumers running
+    ``table.set_cell_text(...)`` on freshly created tables.
+    """
+
+    document = HwpxDocument.new()
+    table = document.add_table(rows=2, cols=2)
+
+    # Both the explicit API and the property setter must succeed.
+    table.set_cell_text(0, 0, "hello")
+    cells = list(table.rows[1].cells)
+    cells[1].text = "world"
+
+    assert table.rows[0].cells[0].text == "hello"
+    assert table.rows[1].cells[1].text == "world"
+
+
+def test_issue_30_add_run_bold() -> None:
+    """``paragraph.add_run(text, bold=True)`` must not raise ``TypeError``.
+
+    Before the fix, ``ensure_run_style``'s ``modifier`` closure called
+    ``ET.SubElement(element, ...)`` where ``element`` is an lxml element.
+    This is the original reproduction from the body of issue #30.
+    """
+
+    document = HwpxDocument.new()
+    paragraph = document.add_paragraph("")
+    run = paragraph.add_run("hello", bold=True)
+
+    assert run.text == "hello"


### PR DESCRIPTION
Closes #30.

## Root cause

`HwpxOxmlTableCell._ensure_text_element` and the `modifier` closure inside `ensure_run_style` were still calling stdlib `ET.SubElement` on elements that were actually `lxml.etree._Element` instances, which raises:

```
TypeError: SubElement() argument 1 must be xml.etree.ElementTree.Element,
not lxml.etree._Element
```

This broke every downstream consumer that touched cell text (`table.set_cell_text(...)`, `cell.text = "..."` on a blank cell) or set a run style (`paragraph.add_run(text, bold=True)`). The issue body (@xoxown31) covers the `add_run(bold=True)` path; the first comment (@devnoff) covers `cell.text = "..."` on blank form cells.

## Fix

`src/hwpx/oxml/document.py` already ships a backend-agnostic helper `_append_child` (introduced in the lxml refactor) that uses `parent.makeelement(tag, attrib)` so the child type matches the parent regardless of which backend produced it. This PR simply makes the two remaining stdlib `ET.SubElement` call sites use that existing helper — no new abstractions, no API changes.

Two sites were updated:

1. `HwpxOxmlTableCell._ensure_text_element` — was calling `ET.SubElement` four times to create `<hp:subList>`, `<hp:p>`, `<hp:run>`, `<hp:t>`. Now uses `_append_child` for all four, matching the pattern already used by `HwpxOxmlRun._ensure_text_element`.
2. `modifier()` inside `ensure_run_style` — was calling `ET.SubElement` for `<hh:bold>`, `<hh:italic>`, `<hh:underline>`. Now uses `_append_child`.

## Regression tests (added)

- `test_issue_30_set_cell_text_on_blank_cell` — covers the cell path (matches @devnoff's comment and downstream hwp-tools reproduction)
- `test_issue_30_add_run_bold` — covers the run-style path (original issue body reproduction)

## Verification

Without this patch, the following downstream code raised `TypeError` unless the caller monkey-patched `hwpx.oxml.document.ET = lxml.etree`:

```python
from hwpx import HwpxDocument

doc = HwpxDocument.new()

# Case 1: set_cell_text on blank cell (devnoff comment)
table = doc.add_table(rows=2, cols=2)
table.set_cell_text(0, 0, 'hello')      # was TypeError

# Case 2: add_run(bold=True) (issue body)
p = doc.add_paragraph("")
p.add_run("hello", bold=True)           # was TypeError

# Case 3: cell.text property setter
cells = list(doc.add_table(1, 1).rows[0].cells)
cells[0].text = 'direct setter'         # was TypeError
```

All three now work end-to-end with this patch applied. See verification in https://github.com/airmang/python-hwpx/issues/30#issuecomment-4302414363.

## Test results

```
250 passed, 2 skipped, 1 warning in 5.89s
```

(Previous baseline was 248 passed; the 2 new tests are the regressions above.)

## Notes

- No public API changes.
- `_append_child` is already used elsewhere in the same file, so this is a consistency/cleanup fix rather than a new abstraction.
- Downstream wrappers (e.g. [`daoleeng/hwp-tools`](https://github.com/daoleeng/hwp-tools)) can drop their `hwpx.oxml.document.ET = lxml.etree` monkey-patch once this lands.