### PR TITLE
fix(oxml): keep generated ids within signed int32 range

### DIFF
--- a/src/hwpx/oxml/document.py
+++ b/src/hwpx/oxml/document.py
@@ -109,17 +109,17 @@ def _serialize_xml(element: ET.Element) -> bytes:
 
 def _paragraph_id() -> str:
     """Generate an identifier for a new paragraph element."""
-    return str(uuid4().int & 0xFFFFFFFF)
+    return str(uuid4().int & 0x7FFFFFFF)
 
 
 def _object_id() -> str:
     """Generate an identifier suitable for table and shape objects."""
-    return str(uuid4().int & 0xFFFFFFFF)
+    return str(uuid4().int & 0x7FFFFFFF)
 
 
 def _memo_id() -> str:
     """Generate a lightweight identifier for memo elements."""
-    return str(uuid4().int & 0xFFFFFFFF)
+    return str(uuid4().int & 0x7FFFFFFF)
 
 
 def _refresh_copied_paragraph_subtree_ids(paragraph: ET.Element) -> None:

--- a/tests/test_id_generator_range.py
+++ b/tests/test_id_generator_range.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from hwpx.oxml.document import _memo_id, _object_id, _paragraph_id
+
+
+_GENERATORS = (_paragraph_id, _object_id, _memo_id)
+
+
+def test_id_generators_stay_within_signed_int32() -> None:
+    """Generated IDs must fit in signed int32 so downstream consumers that
+    parse the ``id`` attribute as ``int`` see a non-negative value."""
+
+    for gen in _GENERATORS:
+        for _ in range(200):
+            value = int(gen())
+            assert 0 <= value < 2**31, (
+                f"{gen.__name__} produced {value} (0x{value:x}); "
+                "must be in [0, 2^31)"
+            )
+
+
+def test_id_generators_use_full_31_bit_range() -> None:
+    """The generators should still draw from a wide range so collisions
+    remain negligible. Sample 4_000 values and require at least one above
+    2^30 to guard against accidental over-restriction."""
+
+    for gen in _GENERATORS:
+        samples = [int(gen()) for _ in range(4000)]
+        assert max(samples) >= 2**30, (
+            f"{gen.__name__} samples capped at {max(samples):#x}; "
+            "expected the full [0, 2^31) range"
+        )


### PR DESCRIPTION

Closes #34.

## Root cause

`_paragraph_id`, `_object_id`, and `_memo_id` in `src/hwpx/oxml/document.py` masked `uuid4().int` with `0xFFFFFFFF`. Since `uuid4().int` is uniformly distributed over 122 bits of entropy, the masked output is uniform over the full unsigned 32-bit range; **about 50% of generated ids have bit 31 set** (i.e. `>= 2^31`).

Downstream consumers that parse the `id` attribute as a signed 32-bit integer interpret those values as negative, which has caused interop issues.

## Fix

Mask one bit lower (`& 0x7FFFFFFF`) so the result fits in `[0, 2^31)` and survives any consumer that uses signed `int32`. Three call sites updated:

```diff
 def _paragraph_id() -> str:
     """Generate an identifier for a new paragraph element."""
-    return str(uuid4().int & 0xFFFFFFFF)
+    return str(uuid4().int & 0x7FFFFFFF)


 def _object_id() -> str:
     """Generate an identifier suitable for table and shape objects."""
-    return str(uuid4().int & 0xFFFFFFFF)
+    return str(uuid4().int & 0x7FFFFFFF)


 def _memo_id() -> str:
     """Generate a lightweight identifier for memo elements."""
-    return str(uuid4().int & 0xFFFFFFFF)
+    return str(uuid4().int & 0x7FFFFFFF)
```

Collision risk is essentially unchanged — birthday probability for `N=10_000` ids drops from ~`2.3e-5` (32-bit) to ~`4.7e-5` (31-bit), which is still negligible for any realistic document size.

## Regression test

`tests/test_id_generator_range.py` (new):

- `test_id_generators_stay_within_signed_int32` — samples 200 values from each of the three generators and asserts `0 <= v < 2**31`.
- `test_id_generators_use_full_31_bit_range` — samples 4,000 values from each generator and asserts at least one is `>= 2^30`, guarding against accidental over-restriction (e.g. a future change that masks too many bits).

Without the fix, `test_id_generators_stay_within_signed_int32` fails immediately:

```
AssertionError: _paragraph_id produced 3521445198 (0xd1e4fd4e); must be in [0, 2^31)
```

With the fix:

```
$ pytest tests/test_id_generator_range.py
tests/test_id_generator_range.py ..                                      [100%]
============================== 2 passed in 0.06s ===============================
```

## Wider regression check

```
$ pytest tests/test_id_generator_range.py tests/test_oxml_parsing.py tests/test_document_save_api.py
14 passed, 2 skipped in 0.12s
```

(2 skips are pre-existing, due to absent sample HWPX fixtures in this checkout.)

## Notes

- This PR is intentionally minimal: only the three random ID generators are touched.
- The `_allocate_*_id` helpers (`_allocate_char_property_id`, `_allocate_border_fill_id`, `_allocate_bin_item_id`) propagate `max(numeric_ids) + 1`. They will start producing in-range values once the input document also has in-range ids — that is a follow-up topic and not part of this PR.
- `src/hwpx/data/Skeleton.hwpx` ships with `<hp:p id="3121190098">` (`>= 2^31`). That is filed separately as #35 and patched separately so the two fixes can land independently.
