### PR TITLE
Release 2.9.1 — interop bug fixes + contributors credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,26 @@
 - fixture matrix 기반 Phase 1 validation 리포트(`shared/hwpx/HWPX_STACK_VALIDATION_2026-04-20_pre-phase1.md`, `..._post-phase1.md`)와 회귀 테스트를 추가했습니다.
 
 ### 변경
-- License relicensed to Apache-2.0 (sole author, full consent).
-- Previous license terms no longer apply to future releases.
 - `hwpx-validate`는 이제 기본 strict 모드로 Phase 1 subset schema bundle을 사용합니다. `--no-strict`로 warning-only 분류를 지원합니다.
 - `HwpxDocument.validate()`는 기본 `strict=False`로 동작하며, `validate_on_save_strict` 옵션으로 저장 시 strict 검증을 제어할 수 있습니다.
 - 패키지 배포물(sdist/wheel)에 OWPML subset schema bundle이 포함되도록 package-data를 확장했습니다.
+
+## [2.9.1] - 2026-04-27
+
+상호운용성(interop) 버그 묶음 릴리즈입니다. 외부 기여자들이 보고하고 수정한 세 가지 문제를 정리합니다.
+
+### 수정
+- `HwpxOxmlTableCell._ensure_text_element`와 `ensure_run_style` 내 modifier가 lxml 엘리먼트 상에서 또한 `ET.SubElement`를 호출해 `TypeError`를 발생시키던 경로를 기본 헬퍼 `_append_child`로 정리했습니다. 이제 `cell.text = ...`와 `paragraph.add_run(..., bold=True)`가 monkey-patch 없이 정상 동작합니다 (#30, [@hhy827](https://github.com/hhy827)).
+- `_paragraph_id` / `_object_id` / `_memo_id`가 `uuid4().int & 0xFFFFFFFF`로부터 signed int32 범위를 벗어나는 값을 약 50% 확률로 생성하던 문제를 수정했습니다. id 값을 signed 32-bit 양수 범위(`0 <= x < 2^31`)로 클램프해 downstream 소비자와의 상호운용성을 확보했습니다 (#34, [@seonghoony](https://github.com/seonghoony)).
+- `HwpxDocument.new()`의 seed로 쓰이는 번들 `Skeleton.hwpx`에 signed int32 범위를 벗어나는 `<hp:p id="3121190098">`가 포함돼 있던 문제를 수정했습니다 (#35, [@seonghoony](https://github.com/seonghoony)).
+- `pyproject.toml`에 PEP 639 `license` expression과 같이 남아 있던 legacy `License :: OSI Approved :: Apache Software License` classifier를 제거해 `setuptools>=77`에서의 소스 설치/바이너리 빌드 실패를 해소했습니다.
+
+### 추가
+- 위 세 버그에 대한 회귀 테스트를 추가했습니다 (`tests/test_document_formatting.py`, `tests/test_id_generator_range.py`, `tests/test_skeleton_template_ids.py`).
+- 머지된 기여를 인정하는 `CONTRIBUTORS.md`를 추가하고 `README.md` / `CONTRIBUTING.md`에서 연결했습니다.
+
+### 변경
+- License relicensed to Apache-2.0 (sole author, full consent). Previous license terms no longer apply to future releases.
 
 ## [2.9.0] - 2026-04-02
 ### 추가

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,11 @@
 오타 수정부터 새 파서 추가까지 모든 기여를 환영합니다. HWPX 생태계를 위한
 더 나은 도구를 함께 만들어 주셔서 감사합니다!
 
+## 기여자 명단
+
+머지된 PR이나 반영된 이슈 제보로 기여해 주신 분들은 [`CONTRIBUTORS.md`](CONTRIBUTORS.md)에
+릴리즈 단위로 등재됩니다. 릴리즈 노트와 `CONTRIBUTORS.md` 모두에서 이름을 확인하실 수 있습니다.
+
 ## 타입 힌트 및 `from __future__ import annotations` 정책
 
 - 이 저장소는 Python 3.10을 최소 지원 버전으로 유지하므로, 타입 힌트는 `list`/`dict`/`tuple` 같은 **내장 제네릭(PEP 585)** 을 우선 사용합니다.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,27 @@
+# Contributors
+
+`python-hwpx`는 공개 기여를 반영하며 성장합니다. 이 문서는 코드·테스트·문서·이슈 리포팅 등 의미 있는 기여를 해 주신 분들을 기록합니다.
+
+기여자 목록은 시간 역순(최근 기여가 위)입니다. 새 기여자를 추가할 때는 해당 릴리즈 항목 아래에 `- Name ([@github-handle](https://github.com/github-handle)) — 기여 내용` 형식으로 적어 주세요.
+
+## 2.9.1
+
+- Seonghoon Jeong ([@seonghoony](https://github.com/seonghoony)) — signed int32 범위 밖 ID 생성 버그 수정 (#34), 번들 Skeleton 템플릿 재생성 (#35), 회귀 테스트 추가.
+- YuliusHam ([@hhy827](https://github.com/hhy827)) — lxml 엘리먼트 상에서 `ET.SubElement` 호출로 인한 셀 텍스트/런 스타일 수정 경로의 `TypeError` 수정 (#30), 회귀 테스트 추가.
+
+## Earlier
+
+- devnoff ([@devnoff](https://github.com/devnoff)) — 셀 텍스트 경로의 `TypeError` 별도 재현 및 수정안 상세 제보 (#30 코멘트).
+- 그리고 이슈·토론·문서 개선에 기여해 주신 모든 분들. 더 기록해야 할 이름이 있다면 PR이나 이슈로 알려 주세요.
+
+---
+
+## 기여자 등재 기준
+
+아래 중 하나에 해당하면 본 문서에 등재됩니다.
+
+- 머지된 pull request (코드, 테스트, 문서 모두 포함)
+- 재현 단계·수정안·패치 제안을 포함한 이슈 제보로, 수정안이 실제로 반영된 경우
+- 보안 취약점 책임 공개 (Responsible Disclosure)
+
+단순 "+1" 또는 중복 제보 코멘트는 제외합니다. 애매한 경우 기여자 본인의 의사를 우선 존중합니다.

--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ pip install -e ".[dev]"
 pytest
 ```
 
+머지된 기여자 목록은 [CONTRIBUTORS.md](CONTRIBUTORS.md)에서 확인할 수 있습니다.
+
 ## License
 Apache License 2.0. See LICENSE and NOTICE.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-hwpx"
-version = "2.9.0"
+version = "2.9.1"
 description = "한글 없이 HWPX 문서를 열고, 편집하고, 생성하고, 검증하는 Python 자동화 라이브러리"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "Apache-2.0"
@@ -16,7 +16,6 @@ authors = [
 keywords = ["hwp", "hwpx", "hancom", "opc", "xml", "document-automation", "validation", "template"]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/tests/test_packaging_license_metadata.py
+++ b/tests/test_packaging_license_metadata.py
@@ -9,7 +9,7 @@ from zipfile import ZipFile
 import pytest
 
 
-LICENSE_EXPRESSION = "LicenseRef-python-hwpx-NonCommercial"
+LICENSE_EXPRESSION = "Apache-2.0"
 
 
 def _build_distribution(tmp_path: Path, distribution: str) -> Path:


### PR DESCRIPTION
## 요약

2.9.0 이후 병합된 외부 기여자 3개 PR(#31, #36, #37)을 묶어 **2.9.1** 패치 릴리즈로 내보내기 위한 릴리즈 PR입니다. 함께 2.9.0 상태에서 누락됐던 몇 가지 정합성 문제를 해소합니다.

## 포함 내용

1. **docs: CONTRIBUTORS.md 추가** — 이번 릴리즈에 반영된 외부 기여를 기록합니다.
   - @seonghoony (#36, #37)
   - @hhy827 (#31)
   - @devnoff (#30 재현/수정안 제보)
   - `README.md`, `CONTRIBUTING.md`에서 새 파일로 링크합니다.

2. **chore(packaging): 2.9.1 버전 범프 + legacy license classifier 제거**
   - `pyproject.toml`에 PEP 639 `license` expression과 legacy `License :: OSI Approved :: Apache Software License` classifier가 공존해 `setuptools>=77` 기준 `pip install -e .` / `python -m build`가 실패했습니다. classifier 제거로 해결했습니다.
   - 재현:
     \`\`\`
     InvalidConfigError: License classifiers have been superseded by license expressions (PEP 639).
     Please remove:  License :: OSI Approved :: Apache Software License
     \`\`\`

3. **docs: CHANGELOG 2.9.1 섹션 고정**
   - 릴리즈 범위만 2.9.1로 분리하고, Unreleased에 있던 schema-validation 관련 항목은 그대로 Unreleased로 남겨 두었습니다(현재 머지되지 않은 feature 범위).

4. **test(packaging): Apache-2.0 relicense 후속 정리**
   - `tests/test_packaging_license_metadata.py`가 여전히 과거 `LicenseRef-python-hwpx-NonCommercial`을 검증하고 있어 dev deps 설치 시 실패했습니다. Apache-2.0 기준으로 정정했습니다.

## 검증

- 로컬(Python 3.11, lxml 5.4): \`pytest tests/\` → **253 passed, 2 skipped, 0 failed** (skipped는 외부 샘플 패키지 부재 케이스).
- \`python -m build\` → sdist + wheel 모두 성공.
- 실전 회귀 확인 (2.9.0에서 깨지던 시나리오):
  - \`add_run(bold=True)\` ✅
  - subList 제거된 form 셀에 \`cell.text = ...\` ✅
  - 50 paragraph + 5 table 생성 후 모든 \`id\` 속성이 signed int32 내부에 존재 ✅
  - round-trip (save → open → re-save) ✅

## 머지 이후 해야 할 작업 (별도 PR/태그)

1. \`main\`에서 **v2.9.1 태그 푸시 → GitHub Release 노트 작성** (contributors thank-you 포함).
2. PyPI 업로드 (Trusted Publisher 워크플로 또는 수동).
3. **hwpx-mcp-server**에서 \`python-hwpx>=2.9.1\` bump + \`_patch_upstream_id_generators_to_signed_int32\` shim 제거 PR.

## 연결 이슈

- airmang/python-hwpx#30 (close on merge)
- airmang/python-hwpx#34 (close on merge)
- airmang/python-hwpx#35 (close on merge)

## 검토 포인트

- CHANGELOG에서 Unreleased와 2.9.1 분리 경계가 의도하신 범위와 일치하는지 확인 부탁드립니다.
- CONTRIBUTORS.md 문구와 등재 기준이 이후 릴리즈에도 이어갈 수 있는 템플릿인지 점검해 주세요.