### PR TITLE
ci(release): skip [Unreleased] changelog section for tag-based releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,17 @@ jobs:
           from pathlib import Path
 
           changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
-          match = re.search(r"^## \[([^\]]+)\]", changelog, re.MULTILINE)
-          if not match:
+          # Skip the conventional [Unreleased] heading so keep-a-changelog
+          # workflow (pre-collecting notes above the released version) is
+          # preserved alongside tag-based release automation.
+          matches = re.findall(r"^## \[([^\]]+)\]", changelog, re.MULTILINE)
+          version = next(
+              (m.strip() for m in matches if m.strip().lower() != "unreleased"),
+              None,
+          )
+          if version is None:
               raise SystemExit("CHANGELOG.md에서 버전 섹션(## [x.y.z])을 찾지 못했습니다.")
-          print(match.group(1).strip())
+          print(version)
           PY
           )
 
@@ -72,7 +79,15 @@ jobs:
           from pathlib import Path
 
           lines = Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
-          start = next((i for i, line in enumerate(lines) if line.startswith("## [")), None)
+          # Find the first released version heading, skipping [Unreleased].
+          start = next(
+              (
+                  i
+                  for i, line in enumerate(lines)
+                  if line.startswith("## [") and "unreleased" not in line.lower()
+              ),
+              None,
+          )
           if start is None:
               raise SystemExit("CHANGELOG.md에서 릴리스 섹션을 찾지 못했습니다.")
 


### PR DESCRIPTION
## 문제

릴리즈 워크플로가 CHANGELOG.md의 첫 `## [...]` 헤더를 버전 섹션으로 해석합니다. 관용적인 keep-a-changelog 구조에서는 `[Unreleased]`가 항상 맨 위에 있어, 태그를 밀면 validator가 `CHANGELOG_VERSION=Unreleased`로 읽고 tag/version 일치 검증에서 실패합니다. 실제로 v2.9.1 태그 푸시를 준비하는 과정에서 부딪혔습니다.

## 수정

두 곳 모두 `[Unreleased]` 헤더를 명시적으로 건너뛰도록 정리했습니다.

- `Validate tag/version consistency` 스텝의 CHANGELOG 파서
- `Extract latest changelog section for release notes` 스텝

## 로컬 검증

```
resolved changelog version: 2.9.1
OK
release_notes.md 첫 줄: '## [2.9.1] - 2026-04-27'
```

## 기대 효과

- 태그 푸시 전에 `[Unreleased]` 블록을 비우지 않아도 릴리즈가 통과합니다.
- keep-a-changelog 운영(다음 릴리즈 노트를 Unreleased에 선적재) 패턴이 자연스럽게 지원됩니다.

## 후속

머지 직후 v2.9.1 태그를 푸시해 실제 릴리즈 파이프라인이 새 로직으로 돌아가는지 확인합니다.