### PR TITLE
Relax lxml upper bound to <7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Text Processing :: Markup :: XML",
 ]
 dependencies = [
-    "lxml>=4.9,<6",
+    "lxml>=4.9,<7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Why

The current pin `lxml>=4.9,<6` makes `pip install python-hwpx` fail on **Python 3.14**: lxml 5.x has no prebuilt wheels for 3.14, so pip falls back to a source build (which fails without a libxml2 toolchain). lxml 6.x does ship 3.14 wheels, but the `<6` bound excludes it.

## Evidence that lxml 6 works

Tested on Windows, **Python 3.14.x + lxml 6.0.2** (installed with `pip install --no-deps python-hwpx`):

- Full test suite: **1274 passed, 0 failed** (54 skipped = Hancom Office / macOS oracle tests, 1 xfailed = pre-existing expected failure `test_unedited_paragraph_model_roundtrip_is_byte_stable`)
- Real-world usage: document authoring via `hwpx.authoring` Builder API (headings/paragraphs/tables/lists/images), `save_to_path()` + `verify()` all green — we ship python-hwpx as an optional dependency of a Claude Code plugin ([visionit-harness-kit](https://github.com/rolee74/visionit-harness-kit)) for md→hwpx delivery conversion, and currently have to document a `--no-deps` workaround for 3.14 users.

## Change

One line: `"lxml>=4.9,<6"` → `"lxml>=4.9,<7"`.

(한국어 요약: lxml 5.x 는 Python 3.14 휠이 없어 현재 핀으로는 3.14 에서 설치가 실패합니다. lxml 6.0.2 로 전체 테스트 1274건 통과를 확인해 상한을 <7 로 완화 제안드립니다.)