### PR TITLE
docs: 다운로드 배지를 pepy로 교체 (rate limit 회피)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </p>
   <p align="center">
     <a href="https://pypi.org/project/python-hwpx/"><img src="https://img.shields.io/pypi/v/python-hwpx?color=blue&label=PyPI" alt="PyPI"></a>
-    <a href="https://pypi.org/project/python-hwpx/"><img src="https://img.shields.io/pypi/dm/python-hwpx" alt="Downloads"></a>
+    <a href="https://pepy.tech/project/python-hwpx"><img src="https://static.pepy.tech/badge/python-hwpx/month" alt="Downloads"></a>
     <a href="https://pypi.org/project/python-hwpx/"><img src="https://img.shields.io/pypi/pyversions/python-hwpx" alt="Python"></a>
     <a href="https://github.com/airmang/python-hwpx/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/airmang/python-hwpx/tests.yml?branch=main&label=tests" alt="Tests"></a>
     <a href="https://airmang.github.io/python-hwpx/corpus-metrics.html"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fairmang.github.io%2Fpython-hwpx%2F_static%2Fbadge-hancom-open.json" alt="Hancom open"></a>

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,7 +5,7 @@
   </p>
   <p align="center">
     <a href="https://pypi.org/project/python-hwpx/"><img src="https://img.shields.io/pypi/v/python-hwpx?color=blue&label=PyPI" alt="PyPI"></a>
-    <a href="https://pypi.org/project/python-hwpx/"><img src="https://img.shields.io/pypi/dm/python-hwpx" alt="Downloads"></a>
+    <a href="https://pepy.tech/project/python-hwpx"><img src="https://static.pepy.tech/badge/python-hwpx/month" alt="Downloads"></a>
     <a href="https://pypi.org/project/python-hwpx/"><img src="https://img.shields.io/pypi/pyversions/python-hwpx" alt="Python"></a>
     <a href="https://github.com/airmang/python-hwpx/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/airmang/python-hwpx/tests.yml?branch=main&label=tests" alt="Tests"></a>
     <a href="https://airmang.github.io/python-hwpx/corpus-metrics.html"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fairmang.github.io%2Fpython-hwpx%2F_static%2Fbadge-hancom-open.json" alt="Hancom open"></a>


### PR DESCRIPTION
shields의 `pypi/dm` 배지가 간헐적으로 "rate limited by upstream service"를 렌더하는 문제(pypistats 한도) 해결 — pepy.tech 배지는 자체 데이터로 직접 서빙되어 이 문제가 없습니다. 한/영 README 동일 교체.

🤖 Generated with [Claude Code](https://claude.com/claude-code)