### PR TITLE
ci: guard private vulnerability reporting setting

### DIFF
--- a/.github/workflows/security-policy-drift.yml
+++ b/.github/workflows/security-policy-drift.yml
@@ -1,0 +1,54 @@
+name: Security Policy Drift
+
+on:
+  pull_request:
+    paths:
+      - SECURITY.md
+      - .github/workflows/security-policy-drift.yml
+  push:
+    branches:
+      - main
+    paths:
+      - SECURITY.md
+      - .github/workflows/security-policy-drift.yml
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  private-vulnerability-reporting:
+    name: Private vulnerability reporting is enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository security setting
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          repository = os.environ["GITHUB_REPOSITORY"]
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{repository}/private-vulnerability-reporting",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "User-Agent": "security-policy-drift-check",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              payload = json.load(response)
+
+          if payload.get("enabled") is not True:
+              raise SystemExit(
+                  "Private vulnerability reporting is disabled while SECURITY.md "
+                  "advertises the private reporting form."
+              )
+          print(f"Private vulnerability reporting is enabled for {repository}.")
+          PY


### PR DESCRIPTION
## What changed

- add a scheduled and change-triggered check for the repository's Private Vulnerability Reporting setting
- fail when `SECURITY.md` advertises the private report form but the GitHub setting is disabled

## Root cause

`SECURITY.md` linked to GitHub's private report form, but the repository setting was disabled. The documented fallback worked, but the preferred private channel did not.

## Validation

- authenticated GitHub API: `enabled=true`
- unauthenticated GitHub API: `enabled=true`
- workflow YAML parsed locally
- the workflow's exact API check passed locally

Fixes #83