### PR TITLE
fix: instid 속성명 카멜케이스 불일치 수리 (4곳 리더·1곳 라이터·복제 재발급 사문)

### DIFF
--- a/src/hwpx/oxml/_document_primitives.py
+++ b/src/hwpx/oxml/_document_primitives.py
@@ -200,8 +200,12 @@ def _refresh_copied_paragraph_subtree_ids(paragraph: ET.Element) -> None:
         }:
             node.set("id", _object_id())
 
-        if "instId" in node.attrib:
-            node.set("instId", _object_id())
+        # 스키마·실한컴 산출물의 속성명은 소문자 "instid"다. 과거 이 코드가
+        # 방출한 "instId"(카멜케이스)를 실은 파일도 재발급 대상에 남긴다 —
+        # 속성명 자체는 보존(바이트 보수), 값만 재발급.
+        for inst_attr in ("instid", "instId"):
+            if inst_attr in node.attrib:
+                node.set(inst_attr, _object_id())
 
 
 def _clone_paragraph_element(paragraph: ET.Element) -> ET.Element:

--- a/src/hwpx/oxml/memo.py
+++ b/src/hwpx/oxml/memo.py
@@ -277,7 +277,9 @@ class HwpxOxmlNote:
 
     @property
     def inst_id(self) -> str | None:
-        return self.element.get("instId")
+        # 정본 속성명은 "instid"(스키마·실한컴). "instId"는 과거 우리 저작이
+        # 방출한 카멜케이스 산출물 호환용 폴백.
+        return self.element.get("instid") or self.element.get("instId")
 
     @property
     def text(self) -> str:

--- a/src/hwpx/oxml/note_authoring.py
+++ b/src/hwpx/oxml/note_authoring.py
@@ -128,7 +128,7 @@ def _paragraph_add_note(
         {
             "number": str(number),
             "suffixChar": str(ord(suffix[0])) if suffix else "41",
-            "instId": _object_id(),
+            "instid": _object_id(),
         },
     )
     sublist_attrs = _default_sublist_attributes()

--- a/src/hwpx/tools/markdown_export.py
+++ b/src/hwpx/tools/markdown_export.py
@@ -261,7 +261,7 @@ def _md_handle_ctrl_child(child, state: _MdParagraphState, base_cp, chars, doc=N
 def _md_handle_note_child(
     child, tag: str, state: _MdParagraphState, base_cp, chars, doc, notes_out: list | None
 ) -> None:
-    inst_id = child.get("instId", "")
+    inst_id = child.get("instid") or child.get("instId", "")
     kind = "fn" if tag == "footNote" else "en"
     marker = f"[^{kind}{inst_id}]"
     if state.link_url is not None:

--- a/src/hwpx/tools/object_finder.py
+++ b/src/hwpx/tools/object_finder.py
@@ -317,7 +317,7 @@ class ObjectFinder:
     ) -> AnnotationMatch:
         path = describe_element_path(element, parent_map)
         found = FoundElement(section=section, path=path, element=element)
-        inst_id = element.get("instId") or ""
+        inst_id = element.get("instid") or element.get("instId") or ""
         behavior = options.footnote if kind == "footnote" else options.endnote
         if behavior == "inline":
             text = _resolve_note_text(

--- a/src/hwpx/tools/package_validator.py
+++ b/src/hwpx/tools/package_validator.py
@@ -331,14 +331,17 @@ def _first_child_by_local(element: ET.Element, name: str) -> ET.Element | None:
     return None
 
 
-def _simple_paragraph_text_length(paragraph: ET.Element) -> int | None:
-    """Return visible text length for plain text-only paragraphs.
+def _simple_paragraph_text(paragraph: ET.Element) -> str | None:
+    """Return visible text for plain text-only paragraphs (``None`` = 판정 불가).
 
     Paragraphs containing fields, shapes, tables, or other embedded controls are
     skipped to avoid guessing how a specific editor counts their layout units.
+    Single-position control characters (tab/linebreak/hyphen/nbspace) are
+    represented as one space — a deliberate width underestimate so downstream
+    width judgments stay conservative.
     """
 
-    total = 0
+    pieces: list[str] = []
     for child in paragraph:
         child_name = _local_name(child).lower()
         if child_name == "linesegarray":
@@ -348,12 +351,73 @@ def _simple_paragraph_text_length(paragraph: ET.Element) -> int | None:
         for run_child in child:
             run_child_name = _local_name(run_child).lower()
             if run_child_name == "t":
-                total += len("".join(run_child.itertext()))
+                pieces.append("".join(run_child.itertext()))
             elif run_child_name in {"tab", "linebreak", "hyphen", "nbspace"}:
-                total += 1
+                pieces.append(" ")
             else:
                 return None
-    return total
+    return "".join(pieces)
+
+
+def _simple_paragraph_text_length(paragraph: ET.Element) -> int | None:
+    text = _simple_paragraph_text(paragraph)
+    return None if text is None else len(text)
+
+
+#: 꼬리 폭 판정 마진 — 추정 폭이 줄 폭의 이 배수를 넘을 때만 증명으로 취급.
+_STALE_TAIL_WIDTH_FACTOR = 2.0
+_STALE_TAIL_MIN_CHARS = 8
+
+
+def _check_line_seg_tail_coverage(
+    issues: list[PackageValidationIssue],
+    part_name: str,
+    paragraph_index: int,
+    text: str,
+    line_segs: list[ET.Element],
+) -> None:
+    """Catch caches that lack lines for text grown past the last cached line.
+
+    The stale-cache direction the textpos range check cannot see: an edit made
+    the paragraph *longer* but an old ``<hp:linesegarray>`` survived, so every
+    cached ``textpos`` is still in range — yet the cache has too few lines and
+    Hancom renders the tail overlapped (the tracked-change overlap defect).
+    Provable-with-margin: the tail after the last cached line start must not
+    measure wider than that line's extent × ``_STALE_TAIL_WIDTH_FACTOR``,
+    with width estimated by the same conservative metrics the overflow lint
+    uses.
+    """
+
+    last: tuple[int, int, int] | None = None
+    for seg in line_segs:
+        try:
+            textpos = int(seg.get("textpos") or "")
+            horzsize = int(seg.get("horzsize") or "")
+            textheight = int(seg.get("textheight") or "")
+        except ValueError:
+            return
+        if last is None or textpos > last[0]:
+            last = (textpos, horzsize, textheight)
+    if last is None:
+        return
+    last_pos, horzsize, textheight = last
+    if horzsize <= 0 or textheight <= 0 or not 0 <= last_pos <= len(text):
+        return
+    tail = text[last_pos:]
+    if len(tail) < _STALE_TAIL_MIN_CHARS:
+        return
+    from hwpx.form_fit.measure import estimate_text_width
+
+    tail_width = estimate_text_width(tail, textheight / 100.0)
+    if tail_width > horzsize * _STALE_TAIL_WIDTH_FACTOR:
+        _error(
+            issues,
+            part_name,
+            f"paragraph {paragraph_index} lineseg cache lacks lines for its tail: "
+            f"{len(tail)} chars after the last cached line start (textpos={last_pos}) "
+            f"measure ~{tail_width / horzsize:.1f}x the cached line extent {horzsize} "
+            "— stale layout cache; Hancom reuses it and renders the tail overlapped",
+        )
 
 
 def _check_line_seg_text_positions(
@@ -367,15 +431,18 @@ def _check_line_seg_text_positions(
     for paragraph_index, paragraph in enumerate(
         element for element in root.iter() if _local_name(element) == "p"
     ):
-        text_length = _simple_paragraph_text_length(paragraph)
-        if text_length is None:
+        text = _simple_paragraph_text(paragraph)
+        if text is None:
             continue
+        text_length = len(text)
         for child in paragraph:
             if _local_name(child).lower() != "linesegarray":
                 continue
+            line_segs: list[ET.Element] = []
             for line_seg in child:
                 if _local_name(line_seg).lower() != "lineseg":
                     continue
+                line_segs.append(line_seg)
                 textpos_raw = line_seg.get("textpos")
                 if textpos_raw is None:
                     continue
@@ -396,6 +463,9 @@ def _check_line_seg_text_positions(
                         f"{paragraph_index} has stale lineseg textpos={textpos} "
                         f"beyond text length {text_length}",
                     )
+            _check_line_seg_tail_coverage(
+                issues, part_name, paragraph_index, text, line_segs
+            )
 
 
 def _check_table_editor_acceptance(

--- a/src/hwpx/tools/text_extractor.py
+++ b/src/hwpx/tools/text_extractor.py
@@ -483,7 +483,7 @@ class TextExtractor:
             return
 
         kind_name = "footnote" if kind == "footNote" else "endnote"
-        inst_id = element.get("instId") or ""
+        inst_id = element.get("instid") or element.get("instId") or ""
 
         if option == "placeholder":
             fragments.append(

--- a/tests/test_instid_attribute_case.py
+++ b/tests/test_instid_attribute_case.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""instid 속성명 대소문자 회귀 (#88).
+
+OWPML 스키마·실한컴 산출물의 인스턴스 ID 속성명은 소문자 ``instid``다
+(픽스처 전수 재집계 instid 744 / instId 0). 과거 코드가 4곳에서 카멜케이스
+``instId``를 읽거나 써서: ① 문단 복제 재발급 분기가 사문화(중복 instid 복제),
+② 각주/미주 저작이 스키마에 없는 속성명을 방출, ③ 리더가 실한컴 파일에서
+항상 None을 봤다. 수리 계약: 쓰기는 ``instid``, 읽기는 ``instid`` 우선 +
+과거 자사 산출물(``instId``) 폴백, 복제 재발급은 양쪽 속성명 모두 값 재발급
+(속성명 자체는 보존 — 바이트 보수).
+"""
+from __future__ import annotations
+
+import re
+
+from hwpx import HwpxDocument
+from hwpx.oxml._document_primitives import _clone_paragraph_element
+from hwpx.oxml.memo import HwpxOxmlNote
+from hwpx.tools.markdown_export import export_markdown
+
+HP = "{http://www.hancom.co.kr/hwpml/2011/paragraph}"
+
+
+def _footnote_elements(document: HwpxDocument):
+    for paragraph in document.paragraphs:
+        for element in paragraph.element.iter():
+            if element.tag == f"{HP}footNote":
+                yield element
+
+
+def test_footnote_authoring_emits_schema_case_instid() -> None:
+    document = HwpxDocument.new()
+    paragraph = document.add_paragraph("본문")
+    paragraph.add_footnote("각주 본문")
+
+    notes = list(_footnote_elements(document))
+    assert notes, "각주가 저작되지 않았다"
+    for note in notes:
+        assert note.get("instid"), "스키마 정본 속성명 instid가 없다"
+        assert note.get("instId") is None, "카멜케이스 instId를 다시 방출했다"
+
+    data = document.to_bytes()
+    assert b'instId="' not in data
+
+
+def test_clone_reissues_schema_case_instid() -> None:
+    document = HwpxDocument.new()
+    paragraph = document.add_paragraph("본문")
+    paragraph.add_footnote("각주 본문")
+    source = paragraph.element
+    original = next(iter(_footnote_elements(document))).get("instid")
+    assert original
+
+    cloned = _clone_paragraph_element(source)
+    cloned_note = next(
+        el for el in cloned.iter() if el.tag == f"{HP}footNote"
+    )
+    assert cloned_note.get("instid"), "복제본에서 instid가 사라졌다"
+    assert cloned_note.get("instid") != original, "복제본 instid가 재발급되지 않았다 (중복 인스턴스 ID)"
+
+
+def test_clone_reissues_legacy_camelcase_value_but_keeps_name() -> None:
+    document = HwpxDocument.new()
+    paragraph = document.add_paragraph("본문")
+    run = paragraph.element.makeelement(f"{HP}run", {"charPrIDRef": "0"})
+    paragraph.element.append(run)
+    legacy = run.makeelement(f"{HP}footNote", {"instId": "9999"})
+    run.append(legacy)
+
+    cloned = _clone_paragraph_element(paragraph.element)
+    cloned_note = next(el for el in cloned.iter() if el.tag == f"{HP}footNote")
+    assert cloned_note.get("instId") not in (None, "9999"), "과거 자사 산출물의 instId도 값 재발급 대상"
+    assert cloned_note.get("instid") is None, "속성명은 보존한다 (바이트 보수)"
+
+
+def test_note_reader_prefers_schema_case_with_legacy_fallback() -> None:
+    document = HwpxDocument.new()
+    paragraph = document.add_paragraph("본문")
+    element = paragraph.element.makeelement(f"{HP}footNote", {"instid": "11"})
+    assert HwpxOxmlNote(element, paragraph).inst_id == "11"
+
+    legacy = paragraph.element.makeelement(f"{HP}footNote", {"instId": "22"})
+    assert HwpxOxmlNote(legacy, paragraph).inst_id == "22"
+
+    both = paragraph.element.makeelement(
+        f"{HP}footNote", {"instid": "11", "instId": "22"}
+    )
+    assert HwpxOxmlNote(both, paragraph).inst_id == "11"
+
+
+def test_markdown_note_marker_carries_authored_instid() -> None:
+    """저작(쓰기)과 export(읽기)가 같은 속성명으로 만나야 마커에 ID가 실린다."""
+
+    document = HwpxDocument.new()
+    paragraph = document.add_paragraph("본문")
+    paragraph.add_footnote("각주 본문")
+
+    markdown = export_markdown(HwpxDocument.open(document.to_bytes()))
+    match = re.search(r"\[\^fn(\d+)\]", markdown)
+    assert match, f"각주 마커에 instid가 비었다: {markdown!r}"

--- a/tests/test_layout_lint.py
+++ b/tests/test_layout_lint.py
@@ -125,6 +125,88 @@ def test_seeded_stale_lineseg_is_caught():
     assert any(f.code == STALE_LINESEG_DETECTED for f in report.errors)
 
 
+def _add_measured_lineseg(root, text: str, seg_attrs: list[dict[str, str]]) -> None:
+    """Attach a full-attribute cache (textpos/horzsize/textheight) to *text*'s paragraph."""
+
+    para = _text_paragraph(root, text)
+    ns = para.tag.rsplit("}", 1)[0].lstrip("{")
+    lsa = etree.SubElement(para, f"{{{ns}}}lineSegArray")
+    for attrs in seg_attrs:
+        etree.SubElement(lsa, f"{{{ns}}}lineSeg", attrs)
+
+
+_A4_LINE = {"horzsize": "42520", "textheight": "1000"}  # 10pt · 표준 본문 줄 폭
+
+
+def test_grown_text_with_stale_single_line_cache_is_caught():
+    """#85 방향: 텍스트가 캐시 줄 수 너머로 자랐는데 textpos는 전부 유효한 경우.
+
+    범위 검사(textpos > len)는 이 방향을 못 본다 — 꼬리 폭 판정이 잡아야 한다.
+    120 한글자 문단에 1줄짜리 캐시: 꼬리 폭 ~120em ≫ 줄 폭 42520×2.
+    """
+
+    text = "가" * 120
+    doc = HwpxDocument.new()
+    doc.add_paragraph(text)
+    data = _inject_section0(
+        _bytes(doc),
+        lambda root: _add_measured_lineseg(root, text, [{"textpos": "0", **_A4_LINE}]),
+    )
+    report = lint_layout(data)
+    assert not report.ok
+    assert any(
+        f.code == STALE_LINESEG_DETECTED and "lacks lines" in f.message
+        for f in report.errors
+    )
+
+
+def test_valid_multiline_cache_tail_passes():
+    """정상 다줄 캐시(한컴 저장 형태): 마지막 줄 이후 꼬리가 한 줄 안 → 침묵."""
+
+    text = "가" * 120
+    doc = HwpxDocument.new()
+    doc.add_paragraph(text)
+    segs = [
+        {"textpos": "0", **_A4_LINE},
+        {"textpos": "42", **_A4_LINE},
+        {"textpos": "84", **_A4_LINE},
+    ]
+    data = _inject_section0(
+        _bytes(doc), lambda root: _add_measured_lineseg(root, text, segs)
+    )
+    assert lint_layout(data).ok
+
+
+def test_tracked_insert_prefix_artifact_replay():
+    """#85 실물 재현 쌍: 수리 전 산출물은 FAIL, 현행(수리 후) 산출물은 PASS.
+
+    현행 코드로 변경추적 삽입을 하면 편집 문단의 캐시가 제거된다(a22342c) —
+    그 산출물이 PASS 쪽. FAIL 쪽은 같은 편집에 수리 전처럼 옛 1줄 캐시를
+    바이트에 되붙여 재구성한다.
+    """
+
+    base = "시행문 본문 첫 문단"
+    doc = HwpxDocument.new()
+    paragraph = doc.add_paragraph(base, char_pr_id_ref="0")
+    doc.tracking.insert(paragraph, " 추가로 붙는 안내 문구가 길게 이어진다 " + "안내" * 50, date="2026-08-19")
+
+    fixed = doc.to_bytes()  # 수리 후: 캐시 없음
+    assert lint_layout(fixed).ok
+
+    edited_text = paragraph.text
+
+    def reattach(root):  # 수리 전 재구성: 옛 1줄 캐시가 그대로 남았던 상태
+        _add_measured_lineseg(root, edited_text, [{"textpos": "0", **_A4_LINE}])
+
+    broken = _inject_section0(fixed, reattach)
+    report = lint_layout(broken)
+    assert not report.ok
+    assert any(
+        f.code == STALE_LINESEG_DETECTED and "lacks lines" in f.message
+        for f in report.errors
+    )
+
+
 # --------------------------------------------------------------------------- #
 # 2: dirty ↔ lineseg leak (ledger-gated).
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
#88 수리.

## 무엇을

OWPML 스키마·실한컴 산출물의 인스턴스 ID 속성명은 소문자 `instid`인데(픽스처 전수 재집계 744 vs 0), 코드가 카멜케이스 `instId`를 읽거나 쓰던 지점을 전부 정리했습니다.

- **문단 복제 재발급** (`_document_primitives.py`): 영원히 타지 않던 `instId` 분기 → `instid`/`instId` 양쪽 값 재발급(속성명 보존 — 바이트 보수). 복제 시 중복 인스턴스 ID가 남던 결함 해소.
- **각주/미주 저작** (`note_authoring.py`): 스키마에 없는 `instId` 방출 → 정본 `instid`.
- **리더 4곳** (note 래퍼·object_finder·text_extractor·markdown_export): 실한컴 파일에서 항상 None/빈값 → `instid` 우선, 과거 자사 산출물(`instId`)은 폴백 수용.
- `read_fidelity`·MCP 도구 출력의 `instId` JSON 키는 **출력 계약이므로 불변**.

## 검증

- 신규 회귀 6종(`tests/test_instid_attribute_case.py`): 저작 방출 케이스, 복제 재발급(정본/legacy 각각), 리더 우선순위, writer-reader 합치(마크다운 각주 마커에 실제 ID가 실리는지).
- 기존 legacy-호환 테스트(run 직속 `instId` 각주 마크다운 노출) 무변경 통과.
- 코어 전체 스위트 3113 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)