### PR TITLE
feat: reorder_rows 표 구조 op — 편집기 [표>정렬…] 엔진 갭 상환

### DIFF
--- a/docs/editor-menu-reverse-map.md
+++ b/docs/editor-menu-reverse-map.md
@@ -80,7 +80,7 @@ Windows 한컴 전용 표면은 이 스캔으로 부재를 단정할 수 없다.
 | 모두 선택 | [스코프 밖] | 선택 동작 — UI 상태 |
 | 글자 바꾸기 | [대응 영역] | 찾아바꾸기(`doc.text.replace`) |
 | 찾기 | [대응 영역] | 찾아바꾸기(`doc.text.find_runs`) |
-| 정렬… | [부분 대응] | **트레인㊺ 판정**: 스키마에 "정렬" 관련 어휘는 없음(예상대로 — 데이터 재배치는 새 요소가 아니라 기존 `hp:tr`/`hp:p`의 순서 문제). `table_patch.py`에 행 단위 clone/delete/split/merge/height 프리미티브(`_insert_row_by_clone`/`_insert_block_by_clone`/`_delete_rows`/`_split_table_rows`/`_merge_table_rows`/`_set_row_heights`)는 있으나 **행 재배열(move/swap/reorder) 프리미티브가 없다**(전수 grep 무결과) — 요소 모델은 이미 완전히 이해됐으니 XML 리버스는 불필요하고, `_parse_table`/`_rebuild` 위에 정렬 로직만 얹으면 되는 순수 엔지니어링 갭. 활성화 조건(표뿐인지 문단 목록도인지)은 여전히 실측 필요하나 core 저작 API 부재라는 결론에는 영향 없음 |
+| 정렬… | [부분 대응] | **트레인㊺ 판정**: 스키마에 "정렬" 관련 어휘는 없음(예상대로 — 데이터 재배치는 새 요소가 아니라 기존 `hp:tr`/`hp:p`의 순서 문제). `table_patch.py`에 행 단위 clone/delete/split/merge/height 프리미티브(`_insert_row_by_clone`/`_insert_block_by_clone`/`_delete_rows`/`_split_table_rows`/`_merge_table_rows`/`_set_row_heights`)는 있으나 **행 재배열(move/swap/reorder) 프리미티브가 없다**(전수 grep 무결과) — 요소 모델은 이미 완전히 이해됐으니 XML 리버스는 불필요하고, `_parse_table`/`_rebuild` 위에 정렬 로직만 얹으면 되는 순수 엔지니어링 갭. 활성화 조건(표뿐인지 문단 목록도인지)은 여전히 실측 필요하나 core 저작 API 부재라는 결론에는 영향 없음. **현행화(왕복 충실도 사이클): `_reorder_rows`/`reorder_rows` op가 `table_patch.py`에 실재** — 완전 순열 재배열 + rowAddr 재기입, 수직 병합은 typed refuse. 남은 것은 정렬 키 비교 로직(호출자 몫)과 응용 계층 노출 |
 | 자동 완성 | [스코프 밖] | 대화형 입력 보조(타이핑 중 자동완성 제안) — 문서 형식 자체 아님 |
 | 받아쓰기 시작 | [스코프 밖] | 음성 인식(dictation) — 언어 도구 스코프 밖 기존 원칙(맞춤법 검사·한자 변환과 동일 분류) |
 

--- a/src/hwpx/table_patch.py
+++ b/src/hwpx/table_patch.py
@@ -1053,6 +1053,34 @@ def _delete_rows(table: str, del_rows: Iterable[int]) -> str:
     return _rebuild(prefix, rows, suffix, rowcnt=len(rows))
 
 
+def _reorder_rows(table: str, order: Sequence[int]) -> str:
+    """물리 행 재배열 — 편집기 [표>정렬…] 대응의 엔진 프리미티브.
+
+    *order*는 현재 물리 행 인덱스의 완전 순열: 새 ``i``번째 행 = 기존
+    ``order[i]``. 행 문자열을 통째로 옮기고 각 셀의 ``rowAddr``만 목적지
+    인덱스로 재기입한다(행 높이·서식·문단은 행과 함께 이동). 수직 병합
+    (rowSpan>1)이 하나라도 있으면 refuse — 병합 블록을 가로지르는 재배열은
+    의미가 정의되지 않는다. 정렬 키 비교(어떤 순서로 놓을지)는 호출자 몫이다.
+    """
+    _guard_flat(table)
+    prefix, rows, suffix = _parse_table(table)
+    if sorted(order) != list(range(len(rows))):
+        raise TableStructureError(
+            f"reorder_rows: order must be a permutation of 0..{len(rows) - 1}, got {list(order)}"
+        )
+    for row in rows:
+        for tc in _S_TC.findall(row):
+            if (_si(tc, "cellSpan", "rowSpan") or 1) > 1:
+                raise TableStructureError(
+                    "reorder_rows: vertical merge (rowSpan>1) present — refuse"
+                )
+    new_rows = [
+        _map_cells(rows[src], lambda tc, dest=dest: _ss(tc, "cellAddr", "rowAddr", dest))
+        for dest, src in enumerate(order)
+    ]
+    return _rebuild(prefix, new_rows, suffix)
+
+
 _PARA_ID_RE = re.compile(r'(<hp:p\b[^>]*\bid=")(\d+)(")')
 
 
@@ -1389,6 +1417,7 @@ def _widths_arg(o: Mapping[str, Any]) -> dict[int, int]:
 _STRUCT_OPS = {
     "delete_column": lambda t, o: _collapse_empty_rows(_delete_columns(t, o["cols"] if "cols" in o else [o["col"]])),
     "delete_row": lambda t, o: _delete_rows(t, o["rows"] if "rows" in o else [o["row"]]),
+    "reorder_rows": lambda t, o: _reorder_rows(t, [int(x) for x in o["order"]]),
     "insert_row_by_clone": lambda t, o: _insert_row_by_clone(t, o["ref_row"], int(o.get("count", 1))),
     "insert_block_by_clone": lambda t, o: _insert_block_by_clone(t, int(o["ref_rows"][0]), int(o["ref_rows"][1]), int(o.get("count", 1))),
     "set_column_widths": lambda t, o: _set_column_widths(t, _widths_arg(o)),

--- a/tests/test_table_patch.py
+++ b/tests/test_table_patch.py
@@ -517,3 +517,70 @@ def test_fill_with_max_lines_shrinks_when_warranted(merged):
                 assert len(re.findall(rb'<hh:charPr\b', _header(res.data)[1])) > len(re.findall(rb'<hh:charPr\b', header))
                 return
     pytest.skip("no cell in fixture produced a confident font shrink")
+
+
+# --- reorder_rows (편집기 [표>정렬…] 대응 프리미티브) --------------------------
+
+
+def _row_texts(tbl: bytes) -> list[str]:
+    _p, rows, _s = _parse_table(tbl.decode("utf-8"))
+    return [
+        "".join(re.findall(r"<hp:t>(.*?)</hp:t>", r, re.DOTALL)) for r in rows
+    ]
+
+
+def _row_addrs(tbl: bytes) -> list[list[int]]:
+    _p, rows, _s = _parse_table(tbl.decode("utf-8"))
+    return [
+        [int(m) for m in re.findall(r'rowAddr="(\d+)"', r)] for r in rows
+    ]
+
+
+def test_reorder_rows_permutes_rows_and_renumbers_addrs(merged):
+    def flat(tbl: bytes) -> bool:
+        _p, rows, _s = _parse_table(tbl.decode("utf-8"))
+        return len(rows) >= 2 and all(
+            int(m) == 1 for m in re.findall(r'rowSpan="(\d+)"', tbl.decode("utf-8"))
+        )
+
+    ti = _find_table(merged, flat)
+    assert ti is not None, "flat table fixture not found"
+    sec0, spans0 = _tables(merged)
+    before = _row_texts(sec0[spans0[ti][0]:spans0[ti][1]])
+    n = len(before)
+    order = list(reversed(range(n)))
+
+    res = apply_table_ops(merged, [{"op": "reorder_rows", "table_index": ti, "order": order}])
+    assert res.ok, res.skipped
+    sec1, spans1 = _tables(res.data)
+    tbl1 = sec1[spans1[ti][0]:spans1[ti][1]]
+    assert _row_texts(tbl1) == list(reversed(before)), "행 내용이 순열대로 재배열되어야 한다"
+    for dest, addrs in enumerate(_row_addrs(tbl1)):
+        assert all(a == dest for a in addrs), f"행 {dest}의 rowAddr가 재기입되지 않았다: {addrs}"
+    _grid, rep = build_grid(tbl1)
+    assert rep.ok and rep.row_count == n
+
+
+def test_reorder_rows_refuses_vertical_merge(merged):
+    def has_vmerge(tbl: bytes) -> bool:
+        return any(int(m) > 1 for m in re.findall(r'rowSpan="(\d+)"', tbl.decode("utf-8")))
+
+    ti = _find_table(merged, has_vmerge)
+    assert ti is not None
+    sec0, spans0 = _tables(merged)
+    n = len(_row_texts(sec0[spans0[ti][0]:spans0[ti][1]]))
+    res = apply_table_ops(merged, [{"op": "reorder_rows", "table_index": ti, "order": list(reversed(range(n)))}])
+    assert any("rowSpan" in s.reason for s in res.skipped), res.skipped
+    assert res.data == merged, "거절 시 바이트 무변경이어야 한다"
+
+
+def test_reorder_rows_refuses_non_permutation(simple):
+    def flat(tbl: bytes) -> bool:
+        _p, rows, _s = _parse_table(tbl.decode("utf-8"))
+        return len(rows) >= 2
+
+    ti = _find_table(simple, flat)
+    assert ti is not None
+    res = apply_table_ops(simple, [{"op": "reorder_rows", "table_index": ti, "order": [0, 0]}])
+    assert any("permutation" in s.reason for s in res.skipped), res.skipped
+    assert res.data == simple


### PR DESCRIPTION
역매핑 [부분 대응] 행이 지목한 순수 엔지니어링 갭: 행 단위 clone/delete/split/merge/height 프리미티브는 있었으나 재배열(move/reorder)이 없었습니다.

- `reorder_rows` op (`apply_table_ops`): 완전 순열 기반 물리 행 재배열 + rowAddr 재기입. 행 높이·서식·문단은 행과 함께 이동.
- 수직 병합(rowSpan>1) 표는 typed refuse — 바이트 무변경 보장.
- 비순열 입력 typed refuse. 정렬 키 비교(어떤 순서로 놓을지)는 호출자 몫.
- 역매핑 정렬 행 현행화 동봉. 회귀 3종(순열 재배열·병합 거절·비순열 거절).

🤖 Generated with [Claude Code](https://claude.com/claude-code)